### PR TITLE
update suite for explict txn

### DIFF
--- a/the-suite/src/change_tracking.rs
+++ b/the-suite/src/change_tracking.rs
@@ -82,19 +82,15 @@ impl ChangeTrackingSuite {
         info!("=====running setup script====");
 
         let conn = self.new_connection().await?;
-        let setup_file_path =
-            if self.args.clustered_table {
-                SET_UP_CLUSTERED
-            } else {
-                SET_UP
-            };
+        let setup_file_path = if self.args.clustered_table {
+            SET_UP_CLUSTERED
+        } else {
+            SET_UP
+        };
         info!("setup file path {}", setup_file_path);
         let setup_script = read_to_string(setup_file_path)?;
 
-        let db_set_sqls = vec![
-            "create or replace database test_stream",
-            "use test_stream",
-        ];
+        let db_set_sqls = vec!["create or replace database test_stream", "use test_stream"];
 
         let setup_lines = setup_script.split(';');
 
@@ -352,9 +348,9 @@ impl ChangeTrackingSuite {
         let conn = self.new_connection_with_test_db().await?;
 
         let row = conn.query_row("select count() from sink").await?;
-        let (count, ): (u64, ) = row.unwrap().try_into().unwrap();
+        let (count,): (u64,) = row.unwrap().try_into().unwrap();
         let row = conn.query_row("select sum(a) from sink").await?;
-        let (sum, ): (u64, ) = row.unwrap().try_into().unwrap();
+        let (sum,): (u64,) = row.unwrap().try_into().unwrap();
 
         info!("===========================");
         info!("Sink table: row count: {count}");
@@ -370,11 +366,11 @@ impl ChangeTrackingSuite {
             let row = conn
                 .query_row(format!("select count() from sink_{idx}").as_str())
                 .await?;
-            let (c, ): (u64, ) = row.unwrap().try_into().unwrap();
+            let (c,): (u64,) = row.unwrap().try_into().unwrap();
             let row = conn
                 .query_row(format!("select sum(a) from sink_{idx}").as_str())
                 .await?;
-            let (s, ): (u64, ) = row.unwrap().try_into().unwrap();
+            let (s,): (u64,) = row.unwrap().try_into().unwrap();
             info!(
                 "sink of derived stream {}: row count {}, sum {} ",
                 idx, c, s
@@ -453,7 +449,7 @@ impl ChangeTrackingSuite {
             merge_handle = Some(driver.begin_merge().await?);
             replace_handle = Some(driver.begin_replace().await?);
         }
-        let mut recluster_handle =  None;
+        let mut recluster_handle = None;
 
         if clustered_base_table {
             recluster_handle = Some(driver.begin_recluster().await?);

--- a/txn/src/main.rs
+++ b/txn/src/main.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
 
     c1.exec("CREATE OR REPLACE TABLE t(c int);").await?;
 
-    // c1 commit failed due to c2 has modified the data
+    // c1 commit success, because conflict is detected and resolved
     c1.begin().await?;
     c1.exec("INSERT INTO t VALUES(1);").await?;
     c1.assert_query(select_t, vec![(1,)]).await;
@@ -36,9 +36,9 @@ async fn main() -> Result<()> {
     c2.assert_query(select_t, vec![(2,)]).await;
 
     let result = c1.commit().await;
-    assert!(result.is_err());
-    c1.assert_query(select_t, vec![(2,)]).await;
-    c2.assert_query(select_t, vec![(2,)]).await;
+    assert!(result.is_ok());
+    c1.assert_query(select_t, vec![(1,), (2,)]).await;
+    c2.assert_query(select_t, vec![(1,), (2,)]).await;
 
     // rollback
     c1.begin().await?;
@@ -46,8 +46,8 @@ async fn main() -> Result<()> {
     let result = c1.exec("qwerty").await;
     assert!(result.is_err());
     c1.commit().await?;
-    c1.assert_query(select_t, vec![(2,)]).await;
-    c2.assert_query(select_t, vec![(2,)]).await;
+    c1.assert_query(select_t, vec![(1,), (2,)]).await;
+    c2.assert_query(select_t, vec![(1,), (2,)]).await;
 
     // rollback
     c1.exec("drop table if exists t1;").await?;
@@ -56,8 +56,8 @@ async fn main() -> Result<()> {
     let result = c1.exec("select * from t1").await;
     assert!(result.is_err());
     c1.commit().await?;
-    c1.assert_query(select_t, vec![(2,)]).await;
-    c2.assert_query(select_t, vec![(2,)]).await;
+    c1.assert_query(select_t, vec![(1,), (2,)]).await;
+    c2.assert_query(select_t, vec![(1,), (2,)]).await;
 
     //stream
     c1.exec("create or replace table base(c int);").await?;
@@ -80,18 +80,18 @@ async fn main() -> Result<()> {
     // Third time query stream s
     c1.assert_query("SELECT c FROM s;", vec![(1,)]).await;
     let result = c1.commit().await;
-    assert!(result.is_err());
+    assert!(result.is_ok());
 
     // no conflict, both commit success
-    c1.assert_query(select_t, vec![(2,)]).await;
-    c2.assert_query(select_t, vec![(2,)]).await;
+    c1.assert_query(select_t, vec![(1,), (2,)]).await;
+    c2.assert_query(select_t, vec![(1,), (2,)]).await;
     c1.exec("CREATE OR REPLACE TABLE t1(c int);").await?;
     let select_t1 = "SELECT * FROM t1 ORDER BY c;";
 
     c1.begin().await?;
     c1.exec("INSERT INTO t VALUES(1);").await?;
-    c1.assert_query(select_t, vec![(1,), (2,)]).await;
-    c2.assert_query(select_t, vec![(2,)]).await;
+    c1.assert_query(select_t, vec![(1,), (1,), (2,)]).await;
+    c2.assert_query(select_t, vec![(1,), (2,)]).await;
 
     c2.begin().await?;
     c2.exec("INSERT INTO t1 VALUES(3);").await?;
@@ -100,8 +100,8 @@ async fn main() -> Result<()> {
 
     c2.commit().await?;
     c1.commit().await?;
-    c1.assert_query(select_t, vec![(1,), (2,)]).await;
-    c2.assert_query(select_t, vec![(1,), (2,)]).await;
+    c1.assert_query(select_t, vec![(1,), (1,), (2,)]).await;
+    c2.assert_query(select_t, vec![(1,), (1,), (2,)]).await;
     c1.assert_query(select_t1, vec![(3,)]).await;
     c2.assert_query(select_t1, vec![(3,)]).await;
     println!("All tests passed!");


### PR DESCRIPTION
Some` commit` statements that used to return errors can now be executed correctly.