### PR TITLE
feat: new test case for vacuum2

### DIFF
--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -9,6 +9,8 @@ TEST_TARGETS=(
               "change-tracking --clustered-table --append-only-stream"
               "explicit-txn" "multi-table-insert"
               "auto-vacuum"
+	      "vacuum2"
+	      "vacuum2 --explicit-txn"
               )
 
 for TEST_SUB_COMMAND in "${TEST_TARGETS[@]}"; do

--- a/the-suite/src/auto_vacuum.rs
+++ b/the-suite/src/auto_vacuum.rs
@@ -99,7 +99,7 @@ impl AutoVacuumSuite {
                     info!("INSERT completed successfully");
                 }
                 Err(e) => {
-                    // Allows insertion to fail, e.g. due to concurrent mutations, snapshot working on  may be purged
+                    // Allows insertion to fail, e.g. due to concurrent mutations, snapshot working on may be purged
                     // But table data should NOT be corrupted, i.e. later the table health check should pass
                     info!("INSERT error: {}", e);
                 }

--- a/the-suite/src/main.rs
+++ b/the-suite/src/main.rs
@@ -10,10 +10,12 @@ mod change_tracking;
 mod explict_txn;
 mod multi_table_insert;
 mod util;
+mod vacuum2;
 
 use auto_vacuum::Args as AutoVacuumArgs;
 use change_tracking::Args as ChangeTrackingArgs;
 use change_tracking::ChangeTrackingSuite;
+use vacuum2::Args as Vacuum2Args;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -28,6 +30,7 @@ enum Commands {
     ExplicitTxn,
     MultiTableInsert,
     AutoVacuum(AutoVacuumArgs),
+    Vacuum2(Vacuum2Args),
 }
 
 #[tokio::main]
@@ -45,5 +48,6 @@ async fn main() -> Result<()> {
         Commands::ExplicitTxn => explict_txn::run(dsn).await,
         Commands::MultiTableInsert => multi_table_insert::run(dsn).await,
         Commands::AutoVacuum(cmd_args) => auto_vacuum::run(cmd_args, dsn).await,
+        Commands::Vacuum2(cmd_args) => vacuum2::run(cmd_args, dsn).await,
     }
 }

--- a/the-suite/src/vacuum2.rs
+++ b/the-suite/src/vacuum2.rs
@@ -5,7 +5,6 @@ use clap::Parser;
 use databend_driver::{Client, Connection};
 use log::info;
 use tokio::task::JoinHandle;
-use tokio::time;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Vacuum2 Testing Script - Tests for table corruption with concurrent writes and vacuum operations
@@ -109,8 +108,6 @@ impl Vacuum2Suite {
                     }
                     Err(e) => {
                         info!("INSERT error within transaction: {}", e);
-                        // Try to rollback on error but continue with test
-                        let _ = conn.exec("ROLLBACK").await;
                         return Ok(());
                     }
                 }
@@ -136,8 +133,8 @@ impl Vacuum2Suite {
                         info!("INSERT completed successfully");
                     }
                     Err(e) => {
-                        // It is OK if the insert fails, e.g. due to concurrent mutations
-                        // But table data should NOT be corrupted, i.e. later the table health check should pass
+                        // It is OK if the insert fails, e.g., due to concurrent mutations (especially we are testing with zero retention periods)
+                        // But table data should NOT be corrupted, i.e., later the table health check should pass.
                         info!("INSERT error: {}", e);
                     }
                 }

--- a/the-suite/src/vacuum2.rs
+++ b/the-suite/src/vacuum2.rs
@@ -1,0 +1,240 @@
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use clap::Parser;
+use databend_driver::{Client, Connection};
+use log::info;
+use tokio::task::JoinHandle;
+
+/// Vacuum2 Testing Script - Tests for table corruption with concurrent writes and vacuum operations
+/// - Tests two scenarios: simple concurrent writes and writes within explicit transactions
+#[derive(Parser, Clone, Debug)]
+pub struct Args {
+    /// Number of concurrent writer threads
+    #[arg(long, default_value_t = 10)]
+    writers: u32,
+
+    /// Number of concurrent vacuum executor threads
+    #[arg(long, default_value_t = 3)]
+    vacuumers: u32,
+
+    /// Number of insert operations per thread
+    #[arg(long, default_value_t = 20)]
+    inserts_per_thread: u32,
+
+    /// Number of rows to insert in each operation
+    #[arg(long, default_value_t = 10)]
+    insert_batch_size: u32,
+
+    /// Run scenario with explicit transactions
+    #[arg(long, default_value_t = false)]
+    explicit_txn: bool,
+}
+
+#[derive(Clone)]
+pub struct Vacuum2Suite {
+    args: Args,
+    dsn: String,
+}
+
+impl Vacuum2Suite {
+    fn new(args: Args, dsn: String) -> Self {
+        Self { args, dsn }
+    }
+
+    async fn new_connection(&self) -> Result<Box<dyn Connection>> {
+        let client = Client::new(self.dsn.clone());
+        let conn = client.get_conn().await?;
+        Ok(conn)
+    }
+
+    async fn setup(&self) -> Result<()> {
+        info!("===== Running setup for vacuum2 test =====");
+
+        let conn = self.new_connection().await?;
+
+        // Create test database and tables
+        let setup_sqls = [
+            "CREATE OR REPLACE DATABASE test_vacuum2",
+            "USE test_vacuum2",
+            "CREATE OR REPLACE TABLE t1 (
+                id DECIMAL(38, 0) NOT NULL,
+                a VARIANT NULL,
+                b VARCHAR NULL,
+                c TIMESTAMP NULL DEFAULT CAST(now() AS Timestamp NULL),
+                d TIMESTAMP NULL,
+                e DECIMAL(38, 0) NULL DEFAULT 0,
+                f VARCHAR NULL,
+                g VARCHAR NULL,
+                h VARCHAR NULL
+            )",
+            // Create a random table for data generation
+            "CREATE OR REPLACE TABLE r LIKE t1 ENGINE = random",
+        ];
+
+        for sql in setup_sqls {
+            info!("Executing setup SQL: {}", sql);
+            conn.exec(sql).await?;
+        }
+
+        info!("===== Setup completed =====");
+        Ok(())
+    }
+
+    async fn execute_insert(&self, batch_id: u32) -> Result<()> {
+        let conn = self.new_connection().await?;
+
+        // Set retention period to 0 for more extreme testing
+        conn.exec("SET DATA_RETENTION_NUM_SNAPSHOTS_TO_KEEP = 0").await?;
+        conn.exec("USE test_vacuum2").await?;
+
+        let sql = format!(
+            "INSERT INTO t1 SELECT * FROM r LIMIT {}",
+            self.args.insert_batch_size
+        );
+
+        if self.args.explicit_txn {
+            // Scenario 2: Insert within explicit transaction
+            conn.exec("BEGIN").await?;
+
+            for i in 0..self.args.inserts_per_thread {
+                info!("\n===== Writer {batch_id} Iteration {i} Progress {}% =====",
+                     i * 100 / self.args.inserts_per_thread);
+
+                match conn.exec(&sql).await {
+                    Ok(_) => {
+                        info!("INSERT within transaction completed successfully");
+                    }
+                    Err(e) => {
+                        info!("INSERT error within transaction: {}", e);
+                        // Try to rollback on error but continue with test
+                        let _ = conn.exec("ROLLBACK").await;
+                        return Ok(());
+                    }
+                }
+            }
+
+            // Commit the transaction
+            match conn.exec("COMMIT").await {
+                Ok(_) => {
+                    info!("Transaction committed successfully");
+                }
+                Err(e) => {
+                    info!("Transaction commit error: {}", e);
+                }
+            }
+        } else {
+            // Scenario 1: Simple concurrent inserts
+            for i in 0..self.args.inserts_per_thread {
+                info!("\n===== Writer {batch_id} Iteration {i} Progress {}% =====",
+                     i * 100 / self.args.inserts_per_thread);
+
+                match conn.exec(&sql).await {
+                    Ok(_) => {
+                        info!("INSERT completed successfully");
+                    }
+                    Err(e) => {
+                        info!("INSERT error: {}", e);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn execute_vacuum(&self, vacuum_id: u32) -> Result<()> {
+        let conn = self.new_connection().await?;
+        conn.exec("USE test_vacuum2").await?;
+
+        info!("===== Vacuum thread {vacuum_id} starting =====");
+
+        match conn.exec("CALL system$vacuum2('test_vacuum2', 't1')").await {
+            Ok(_) => {
+                info!("VACUUM completed successfully");
+            }
+            Err(e) => {
+                info!("VACUUM error: {}", e);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn check_table_health(&self) -> Result<bool> {
+        let conn = self.new_connection().await?;
+        conn.exec("USE test_vacuum2").await?;
+        let sql = "SELECT * FROM t1 ignore_result";
+
+        match conn.exec(sql).await {
+            Ok(_) => {
+                info!("Table health check passed");
+                Ok(true)
+            }
+            Err(e) => {
+                info!("ERROR: Table health check failed: {}", e);
+                Ok(false)
+            }
+        }
+    }
+
+    async fn run_concurrent_inserts(&self) -> Result<Vec<JoinHandle<Result<()>>>> {
+        let mut handles = Vec::new();
+
+        for i in 0..self.args.writers {
+            let self_clone = Arc::new(self.clone());
+            let handle = tokio::spawn(async move { self_clone.execute_insert(i).await });
+            handles.push(handle);
+        }
+
+        Ok(handles)
+    }
+
+    async fn run_concurrent_vacuums(&self) -> Result<Vec<JoinHandle<Result<()>>>> {
+        let mut handles = Vec::new();
+
+        for i in 0..self.args.vacuumers {
+            let self_clone = Arc::new(self.clone());
+            let handle = tokio::spawn(async move { self_clone.execute_vacuum(i).await });
+            handles.push(handle);
+        }
+
+        Ok(handles)
+    }
+
+    async fn wait_for_completion(&self, handles: Vec<JoinHandle<Result<()>>>) -> Result<()> {
+        for handle in handles {
+            handle.await??;
+        }
+        Ok(())
+    }
+
+    pub async fn run(args: Args, dsn: String) -> Result<()> {
+        let explicit_txn = args.explicit_txn;
+        let suite = Self::new(args, dsn);
+        suite.setup().await?;
+
+        // Run concurrent writers and vacuumers
+        let scenario_name = if explicit_txn { "explicit transaction" } else { "simple concurrent writes" };
+        info!("===== Running vacuum2 test with {} scenario =====", scenario_name);
+
+        let writer_handles = suite.run_concurrent_inserts().await?;
+        let vacuum_handles = suite.run_concurrent_vacuums().await?;
+
+        // Wait for all writers and vacuumers to complete
+        suite.wait_for_completion(writer_handles).await?;
+        suite.wait_for_completion(vacuum_handles).await?;
+
+        // Check table health
+        if !suite.check_table_health().await? {
+            return Err(anyhow!("Table health check failed. Test terminated."));
+        }
+
+        info!("===== Vacuum2 test with {} scenario completed successfully =====", scenario_name);
+        Ok(())
+    }
+}
+
+pub async fn run(args: Args, dsn: String) -> Result<()> {
+    Vacuum2Suite::run(args, dsn).await
+}


### PR DESCRIPTION
New test case `Vacuum2`:

This test case evaluates the robustness and data integrity of vacuum2 under concurrent write and vacuum operations. 

Scenarios



- Scenario 1: Simple Concurrent Writes

Multiple writer threads concurrently insert data into a test table, each writer thread sets `data_retention_time_in_days` = 0 before performing inserts,  creating extreme conditions for vacuuming.

Multiple vacuum threads continuously execute `system$fuse_vacuum2` operations on the same table, the vacuum operations continue until all insert operations are complete.

- Scenario 2: Explicit Transaction Writes

Similar to Scenario 1, but all insert operations are performed within explicit transactions, writers execute multiple insert statements within a single transaction.
